### PR TITLE
Fix setup.py to import from setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 readme_conts = open("README.rst", "U").read()
 


### PR DESCRIPTION
Fix setup.py to import from setuptools, otherwise it will lack
some options such as --single-version-externally-managed
